### PR TITLE
fix #7 - Add missing quotes in the where option

### DIFF
--- a/archiver_sample.ini
+++ b/archiver_sample.ini
@@ -32,7 +32,7 @@ deleted_column=deleted_at
 # can be override in src section
 # {now}: python interpolation that will set the utcnow sql format date
 # ${deleted_column}, ${retention}: options of the config file
-where=${deleted_column} <= SUBDATE({now}, INTERVAL ${retention})
+where=${deleted_column} <= SUBDATE('{now}', INTERVAL ${retention})
 # Data lifetime
 retention=1 MONTH
 # Coma, cariage return or semicolon separated regexp which define databases to
@@ -52,7 +52,7 @@ src=nova
 dst=db_archiver, file_archiver
 enable=true
 
-# Declare an archiver called 'false'
+# Declare an archiver called 'glance'
 # Read data from src named 'nova'
 # And write data in dst named db_archiver and file_archiver
 # Disable it


### PR DESCRIPTION
The where option is missing quotes around interpolated date which lead to SQL syntax error when running from the example config file.
Also change a wrong comment about archiver name