### PR TITLE
Fix #9 by adding python-dateutil as dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,6 +37,7 @@ setup(name='Openstack Archiver',
           'Topic :: Software Development :: Libraries :: Python Modules'
       ],
       packages=find_packages(".", exclude=('tests')),
-      install_requires=['arrow', 'configparser', 'PyMySQL', 'numpy'],
-      entry_points={'console_scripts': ['osarchiver=osarchiver.main:run']}
-      )
+      install_requires=[
+          'python-dateutil', 'arrow', 'configparser', 'PyMySQL', 'numpy'
+      ],
+      entry_points={'console_scripts': ['osarchiver=osarchiver.main:run']})


### PR DESCRIPTION
Will prevent osarchiver script to fail if library is missing